### PR TITLE
Fix: Update integration name and references

### DIFF
--- a/custom_components/ha-nothink-llm/config_flow.py
+++ b/custom_components/ha-nothink-llm/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for OpenAI Compatible Conversation integration."""
+"""Config flow for No<think> LLM integration."""
 
 from __future__ import annotations
 
@@ -69,7 +69,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     await hass.async_add_executor_job(client.with_options(timeout=10.0).models.list)
 
 
-class OpenAICompatibleConfigFlow(ConfigFlow, domain=DOMAIN):
+class HaNothinkLlmConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenAI Compatible Conversation."""
 
     VERSION = 1
@@ -96,7 +96,7 @@ class OpenAICompatibleConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown"
         else:
             return self.async_create_entry(
-                title="OpenAICompatible",
+                title="No<think> LLM",
                 data=user_input,
                 options=RECOMMENDED_OPTIONS,
             )
@@ -110,10 +110,10 @@ class OpenAICompatibleConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> OptionsFlow:
         """Create the options flow."""
-        return OpenAICompatibleOptionsFlow(config_entry)
+        return HaNothinkLlmOptionsFlow(config_entry)
 
 
-class OpenAICompatibleOptionsFlow(OptionsFlow):
+class HaNothinkLlmOptionsFlow(OptionsFlow):
     """OpenAI Compatible config flow options handler."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
@@ -143,18 +143,18 @@ class OpenAICompatibleOptionsFlow(OptionsFlow):
                 CONF_LLM_HASS_API: user_input[CONF_LLM_HASS_API],
             }
 
-        schema = openai_compatible_config_option_schema(self.hass, options)
+        schema = ha_nothink_llm_config_option_schema(self.hass, options)
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(schema),
         )
 
 
-def openai_compatible_config_option_schema(
+def ha_nothink_llm_config_option_schema(
     hass: HomeAssistant,
     options: dict[str, Any] | MappingProxyType[str, Any],
 ) -> VolDictType:
-    """Return a schema for OpenAI Compatible completion options."""
+    """Return a schema for No<think> LLM completion options."""
     hass_apis: list[SelectOptionDict] = [
         SelectOptionDict(
             label="No control",

--- a/custom_components/ha-nothink-llm/const.py
+++ b/custom_components/ha-nothink-llm/const.py
@@ -1,8 +1,8 @@
-"""Constants for the OpenAI Compatible Conversation integration."""
+"""Constants for the No<think> LLM integration."""
 
 import logging
 
-DOMAIN = "openai_compatible_conversation"
+DOMAIN = "ha-nothink-llm"
 LOGGER = logging.getLogger(__package__)
 
 CONF_RECOMMENDED = "recommended"

--- a/custom_components/ha-nothink-llm/manifest.json
+++ b/custom_components/ha-nothink-llm/manifest.json
@@ -5,7 +5,7 @@
   "codeowners": ["@duckida"],
   "config_flow": true,
   "dependencies": ["conversation"],
-  "documentation": "https://github.com/michelle-avery/openai-compatible-conversation/blob/main/README.md",
+  "documentation": "https://github.com/michelle-avery/ha-nothink-llm/blob/main/README.md",
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "requirements": ["openai>=1.61.0"],

--- a/custom_components/ha-nothink-llm/services.yaml
+++ b/custom_components/ha-nothink-llm/services.yaml
@@ -4,7 +4,7 @@ generate_image:
       required: true
       selector:
         config_entry:
-          integration: openai_compatible_conversation
+          integration: ha-nothink-llm
     prompt:
       required: true
       selector:


### PR DESCRIPTION
The integration was renamed from 'openai_compatible_conversation' to 'ha-nothink-llm'. This commit updates all internal references to the new name to resolve the 'Invalid handler specified' error and ensure correct operation.

Changes include:
- Updated DOMAIN in const.py to 'ha-nothink-llm'.
- Updated the integration reference in services.yaml.
- Renamed ConfigFlow and OptionsFlow classes in config_flow.py.
- Updated various comments, titles, and function names in config_flow.py to reflect the new name.
- Updated the documentation URL in manifest.json.